### PR TITLE
chore: Replacing GSON with Jackson usage/library and removing the GSON dependency from POM as well.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,11 +100,6 @@
             <artifactId>service</artifactId>
             <version>0.14.0</version>
         </dependency>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.10.1</version>
-        </dependency>
     </dependencies>
 
     <build>
@@ -130,7 +125,7 @@
                     <excludes>
                         <exclude>META-INF/VAADIN/config/flow-build-info.json</exclude>
                     </excludes>
-                </configuration>                     
+                </configuration>
             </plugin>
 
             <plugin>

--- a/src/main/java/org/vaadin/addons/ai/formfiller/FormFiller.java
+++ b/src/main/java/org/vaadin/addons/ai/formfiller/FormFiller.java
@@ -1,5 +1,6 @@
 package org.vaadin.addons.ai.formfiller;
 
+import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vaadin.flow.component.Component;
@@ -131,6 +132,7 @@ public class FormFiller {
      */
     private Map<String, Object> promptJsonToMapHierarchyValues(String response) {
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
         Map<String, Object> contentMap = new HashMap<>();
         try {
             contentMap = objectMapper.readValue(response.trim(), new TypeReference<>() {

--- a/src/main/java/org/vaadin/addons/ai/formfiller/FormFiller.java
+++ b/src/main/java/org/vaadin/addons/ai/formfiller/FormFiller.java
@@ -1,7 +1,7 @@
 package org.vaadin.addons.ai.formfiller;
 
-import com.googlecode.gentyref.TypeToken;
-import com.nimbusds.jose.shaded.gson.Gson;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vaadin.flow.component.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,7 +9,6 @@ import org.vaadin.addons.ai.formfiller.services.ChatGPTChatCompletionService;
 import org.vaadin.addons.ai.formfiller.services.LLMService;
 import org.vaadin.addons.ai.formfiller.utils.ComponentUtils;
 
-import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -131,14 +130,12 @@ public class FormFiller {
      * @return Map with components and values
      */
     private Map<String, Object> promptJsonToMapHierarchyValues(String response) {
-        Gson gson = new Gson();
-        Type type = new TypeToken<Map<String, Object>>() {
-        }.getType();
+        ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> contentMap = new HashMap<>();
         try {
-            contentMap = gson.fromJson(response.trim(), type);
-        }
-        catch (Exception e) {
+            contentMap = objectMapper.readValue(response.trim(), new TypeReference<>() {
+            });
+        } catch (Exception e) {
             logger.error("Error parsing AI response to JSON Object: {}", e.getMessage());
         }
         return contentMap;

--- a/src/test/java/org/vaadin/addons/ai/formfiller/utils/OCRUtils.java
+++ b/src/test/java/org/vaadin/addons/ai/formfiller/utils/OCRUtils.java
@@ -86,15 +86,6 @@ public class OCRUtils {
 //            System.out.println("#########################");
 //            System.out.println(response.toString());
 
-//            JsonParser jsonParser = new JsonParser();
-//            JsonObject responseJson = jsonParser.parse(response.toString()).getAsJsonObject();
-//
-//// Extract the 'text' field from the JSON response
-//            JsonArray responsesArray = responseJson.getAsJsonArray("responses");
-//            JsonObject firstResponse = responsesArray.get(0).getAsJsonObject();
-//            JsonObject fullTextAnnotation = firstResponse.getAsJsonObject("fullTextAnnotation");
-//            String extractedText = fullTextAnnotation.get("text").getAsString();
-
             ObjectMapper objectMapper = new ObjectMapper();
             String extractedText = "";
 

--- a/src/test/java/org/vaadin/addons/ai/formfiller/utils/OCRUtils.java
+++ b/src/test/java/org/vaadin/addons/ai/formfiller/utils/OCRUtils.java
@@ -1,5 +1,7 @@
 package org.vaadin.addons.ai.formfiller.utils;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,9 +14,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 public class OCRUtils {
     private static final Logger logger = LoggerFactory.getLogger(OCRUtils.class);
@@ -87,14 +86,27 @@ public class OCRUtils {
 //            System.out.println("#########################");
 //            System.out.println(response.toString());
 
-            JsonParser jsonParser = new JsonParser();
-            JsonObject responseJson = jsonParser.parse(response.toString()).getAsJsonObject();
+//            JsonParser jsonParser = new JsonParser();
+//            JsonObject responseJson = jsonParser.parse(response.toString()).getAsJsonObject();
+//
+//// Extract the 'text' field from the JSON response
+//            JsonArray responsesArray = responseJson.getAsJsonArray("responses");
+//            JsonObject firstResponse = responsesArray.get(0).getAsJsonObject();
+//            JsonObject fullTextAnnotation = firstResponse.getAsJsonObject("fullTextAnnotation");
+//            String extractedText = fullTextAnnotation.get("text").getAsString();
 
-// Extract the 'text' field from the JSON response
-            JsonArray responsesArray = responseJson.getAsJsonArray("responses");
-            JsonObject firstResponse = responsesArray.get(0).getAsJsonObject();
-            JsonObject fullTextAnnotation = firstResponse.getAsJsonObject("fullTextAnnotation");
-            String extractedText = fullTextAnnotation.get("text").getAsString();
+            ObjectMapper objectMapper = new ObjectMapper();
+            String extractedText = "";
+
+            JsonNode responseJson = objectMapper.readTree(response.toString());
+            JsonNode responsesArray = responseJson.get("responses");
+            if (responsesArray != null && responsesArray.isArray() && !responsesArray.isEmpty()) {
+                JsonNode firstResponse = responsesArray.get(0);
+                JsonNode fullTextAnnotation = firstResponse.get("fullTextAnnotation");
+                if (fullTextAnnotation != null) {
+                    extractedText = fullTextAnnotation.get("text").asText();
+                }
+            }
 
             System.out.println("#########################");
             System.out.println("Extracted text:");
@@ -102,7 +114,7 @@ public class OCRUtils {
             System.out.println(extractedText);
             return extractedText;
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error("Error while reading image", e);
         }
         return "";
     }


### PR DESCRIPTION
## Description
As Knoobie suggested the dependency was removed from pom.xml and also the code was refactored wherever the GSON was used before, so in these classes:
- `src/main/java/org/vaadin/addons/ai/formfiller/FormFiller.java`
- `src/test/java/org/vaadin/addons/ai/formfiller/utils/OCRUtils.java`

I have tested with:
- on the `localhost:8080` (text fillign)
- and with two invoices `localhost:8080/invoices` pages (a Hungarian and an English invoices, did not see any errors, problems, the automatic fillings were working as expected)

Fixes # (issue):
- https://github.com/vaadin/form-filler-addon/issues/30

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and correct misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria was created.
