### PR TITLE
feat:  adding support for more components (IntegerField, EmailField, PasswordField, BigDecimalField), 

### DIFF
--- a/src/main/java/org/vaadin/addons/ai/formfiller/FormFiller.java
+++ b/src/main/java/org/vaadin/addons/ai/formfiller/FormFiller.java
@@ -21,7 +21,11 @@ import java.util.Map;
  * Components supported:
  * <ul>
  *     <li>TextField</li>
+ *     <li>EmailField</li>
+ *     <li>PasswordField</li>
  *     <li>NumberField</li>
+ *     <li>IntegerField</li>
+ *     <li>BigDecimalField</li>
  *     <li>DatePicker</li>
  *     <li>TimePicker (WIP)</li>
  *     <li>DateTimePicker</li>

--- a/src/main/java/org/vaadin/addons/ai/formfiller/utils/ComponentUtils.java
+++ b/src/main/java/org/vaadin/addons/ai/formfiller/utils/ComponentUtils.java
@@ -18,6 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -141,10 +142,16 @@ public class ComponentUtils {
         for (ComponentInfo componentInfo : componentInfoList) {
             try {
                 if ((componentInfo.component instanceof TextField)
-                        || (componentInfo.component instanceof TextArea)) {
+                        || (componentInfo.component instanceof TextArea)
+                        || (componentInfo.component instanceof EmailField)
+                        || (componentInfo.component instanceof PasswordField)) {
                     inputFieldMap.put(componentInfo.id, "a String");
                 } else if ((componentInfo.component instanceof NumberField)) {
                     inputFieldMap.put(componentInfo.id, "a Number");
+                } else if ((componentInfo.component instanceof IntegerField)) {
+                    inputFieldMap.put(componentInfo.id, "a Integer");
+                } else if ((componentInfo.component instanceof BigDecimalField)) {
+                    inputFieldMap.put(componentInfo.id, "a Double");
                 } else if ((componentInfo.component instanceof DatePicker)) {
                     inputFieldMap.put(componentInfo.id, "a date using format 'yyyy-MM-dd'");
                 } else if ((componentInfo.component instanceof TimePicker)) {
@@ -245,12 +252,14 @@ public class ComponentUtils {
                         textArea.setValue(responseValue.toString());
                     } else if (componentInfo.component instanceof NumberField numberField) {
                         numberField.setValue(Double.valueOf(responseValue.toString()));
+                    } else if (componentInfo.component instanceof BigDecimalField bdField) {
+                        bdField.setValue(BigDecimal.valueOf(Double.valueOf(responseValue.toString())));
                     } else if (componentInfo.component instanceof IntegerField integerField) {
                         integerField.setValue(Integer.valueOf(responseValue.toString()));
                     } else if (componentInfo.component instanceof EmailField emailField) {
                         emailField.setValue(responseValue.toString());
                     } else if (componentInfo.component instanceof PasswordField passwordField) {
-                      passwordField.setValue(responseValue.toString());
+                        passwordField.setValue(responseValue.toString());
                     } else if (componentInfo.component instanceof DatePicker datePicker) {
                         datePicker.setValue(LocalDate.parse(responseValue.toString()));
                     } else if (componentInfo.component instanceof TimePicker timePicker) {

--- a/src/main/java/org/vaadin/addons/ai/formfiller/utils/ComponentUtils.java
+++ b/src/main/java/org/vaadin/addons/ai/formfiller/utils/ComponentUtils.java
@@ -1,6 +1,8 @@
 package org.vaadin.addons.ai.formfiller.utils;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasComponents;
+import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.flow.component.combobox.ComboBox;
@@ -10,9 +12,7 @@ import com.vaadin.flow.component.datetimepicker.DateTimePicker;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.listbox.MultiSelectListBox;
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
-import com.vaadin.flow.component.textfield.NumberField;
-import com.vaadin.flow.component.textfield.TextArea;
-import com.vaadin.flow.component.textfield.TextField;
+import com.vaadin.flow.component.textfield.*;
 import com.vaadin.flow.component.timepicker.TimePicker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -239,34 +239,32 @@ public class ComponentUtils {
                         } catch (Exception e) {
                             logger.error("Error while updating grid with wildcards", e.getMessage());
                         }
-                    } else if (componentInfo.component instanceof TextField) {
-                        TextField textField = (TextField) componentInfo.component;
+                    } else if (componentInfo.component instanceof TextField textField) {
                         textField.setValue(responseValue.toString());
-                    } else if (componentInfo.component instanceof TextArea) {
-                        TextArea textArea = (TextArea) componentInfo.component;
+                    } else if (componentInfo.component instanceof TextArea textArea) {
                         textArea.setValue(responseValue.toString());
-                    } else if (componentInfo.component instanceof NumberField) {
-                        NumberField numberField = (NumberField) componentInfo.component;
+                    } else if (componentInfo.component instanceof NumberField numberField) {
                         numberField.setValue(Double.valueOf(responseValue.toString()));
-                    } else if (componentInfo.component instanceof DatePicker) {
-                        DatePicker datePicker = (DatePicker) componentInfo.component;
+                    } else if (componentInfo.component instanceof IntegerField integerField) {
+                        integerField.setValue(Integer.valueOf(responseValue.toString()));
+                    } else if (componentInfo.component instanceof EmailField emailField) {
+                        emailField.setValue(responseValue.toString());
+                    } else if (componentInfo.component instanceof PasswordField passwordField) {
+                      passwordField.setValue(responseValue.toString());
+                    } else if (componentInfo.component instanceof DatePicker datePicker) {
                         datePicker.setValue(LocalDate.parse(responseValue.toString()));
-                    } else if (componentInfo.component instanceof TimePicker) {
-                        TimePicker timePicker = (TimePicker) componentInfo.component;
+                    } else if (componentInfo.component instanceof TimePicker timePicker) {
                         timePicker.setValue(LocalTime.parse(responseValue.toString()));
-                    } else if (componentInfo.component instanceof DateTimePicker) {
-                        DateTimePicker datetimePicker = (DateTimePicker) componentInfo.component;
+                    } else if (componentInfo.component instanceof DateTimePicker datetimePicker) {
                         datetimePicker.setValue(LocalDateTime.parse(responseValue.toString()));
-                    } else if (componentInfo.component instanceof ComboBox) {
-                        ComboBox comboBox = (ComboBox) componentInfo.component;
+                    } else if (componentInfo.component instanceof ComboBox comboBox) {
                         comboBox.setValue(responseValue);
-                    } else if (componentInfo.component instanceof MultiSelectComboBox) {
-                        MultiSelectComboBox multiSelectComboBox = (MultiSelectComboBox) componentInfo.component;
+                    } else if (componentInfo.component instanceof MultiSelectComboBox multiSelectComboBox) {
                         multiSelectComboBox.setValue(responseValue);
                     } else if (componentInfo.component instanceof Checkbox) {
                         Checkbox checkbox = (Checkbox) componentInfo.component;
                         checkbox.setValue((Boolean) responseValue);
-                    }  else if (componentInfo.component instanceof CheckboxGroup<?>) {
+                    } else if (componentInfo.component instanceof CheckboxGroup<?>) {
                         CheckboxGroup<String> checkboxgroup = (CheckboxGroup<String>) componentInfo.component;
                         try {
                             ArrayList<String> list = (ArrayList<String>) responseValue;
@@ -276,12 +274,15 @@ public class ComponentUtils {
                             logger.error("Error while updating checkboxgroup with id: {}", id, e);
                         }
                     } else if (componentInfo.component instanceof RadioButtonGroup<?>) {
-                        RadioButtonGroup radioButtonGroup = (RadioButtonGroup) componentInfo.component;
+                        RadioButtonGroup<String> radioButtonGroup = (RadioButtonGroup<String>) componentInfo.component;
                         radioButtonGroup.setValue(responseValue.toString());
                     } else if (componentInfo.component instanceof Grid.Column<?>) {
                         // Nothing to do as it is managed in Grid
-                    }
-
+                    } else if (componentInfo.component instanceof HasValue<?,?>) {
+                        // Fallback to work even if it is not handled here but has Hasvalue.
+                        HasValue<?, String> hasValue = (HasValue<?, String>) componentInfo.component;
+                        hasValue.setValue(responseValue.toString());
+                    }  else logger.warn("Component type not supported: {}", componentInfo.component.getClass().getSimpleName());
                 }
             } catch (Exception e) {
                 logger.error("Error while updating component with id: {} Cause: {}", id, e.getMessage());

--- a/src/test/java/org/vaadin/addons/ai/formfiller/views/FormFillerInvoiceDocDemo.java
+++ b/src/test/java/org/vaadin/addons/ai/formfiller/views/FormFillerInvoiceDocDemo.java
@@ -187,7 +187,7 @@ public class FormFillerInvoiceDocDemo extends Div {
                         if (!c.getValue().isEmpty())
                             contextInformation.add(c.getValue());
                     }
-
+                    clearForm();
                     FormFiller formFiller = new FormFiller(invoiceForm, fieldsInstructions, contextInformation);
                     FormFillerResult result = formFiller.fill(input);
                     debugTool.getDebugPrompt().setValue(result.getRequest() + '\n');

--- a/src/test/java/org/vaadin/addons/ai/formfiller/views/FormFillerReceiptDocDemo.java
+++ b/src/test/java/org/vaadin/addons/ai/formfiller/views/FormFillerReceiptDocDemo.java
@@ -164,7 +164,7 @@ public class FormFillerReceiptDocDemo extends Div {
                         if (extraInstructionsTool.getExtraInstructions().get(c).getValue() != null && !extraInstructionsTool.getExtraInstructions().get(c).getValue().isEmpty())
                             fieldsInstructions.put(c, extraInstructionsTool.getExtraInstructions().get(c).getValue());
                     }
-
+                    clearForm();
                     FormFiller formFiller = new FormFiller(receiptForm, fieldsInstructions);
                     FormFillerResult result = formFiller.fill(input);
                     debugTool.getDebugPrompt().setValue(result.getRequest());

--- a/src/test/java/org/vaadin/addons/ai/formfiller/views/FormFillerTextDemo.java
+++ b/src/test/java/org/vaadin/addons/ai/formfiller/views/FormFillerTextDemo.java
@@ -1,6 +1,7 @@
 package org.vaadin.addons.ai.formfiller.views;
 
 import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.checkbox.Checkbox;
@@ -14,7 +15,11 @@ import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
+import com.vaadin.flow.component.textfield.BigDecimalField;
+import com.vaadin.flow.component.textfield.EmailField;
+import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.flow.component.textfield.NumberField;
+import com.vaadin.flow.component.textfield.PasswordField;
 import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.router.Route;
@@ -50,9 +55,17 @@ public class FormFillerTextDemo extends Div {
         phoneField.setId("phone");
         formLayout.add(phoneField);
 
-        TextField emailField = new TextField("Email");
+        IntegerField age = new IntegerField("age");
+        age.setId("age");
+        formLayout.add(age);
+
+        EmailField emailField = new EmailField("Email");
         emailField.setId("email");
         formLayout.add(emailField);
+
+        PasswordField clientId = new PasswordField("Client Id");
+        clientId.setId("clientId");
+        formLayout.add(clientId);
 
         DateTimePicker dateCreationField = new DateTimePicker("Creation Date");
         dateCreationField.setId("creationDate");
@@ -70,6 +83,10 @@ public class FormFillerTextDemo extends Div {
         NumberField orderTotal = new NumberField("Order Total");
         orderTotal.setId("orderTotal");
         formLayout.add(orderTotal);
+
+        BigDecimalField orderTaxes = new BigDecimalField("Order Taxes");
+        orderTaxes.setId("orderTaxes");
+        formLayout.add(orderTaxes);
 
         TextArea orderDescription = new TextArea("Order Description");
         orderDescription.setId("orderDescription");
@@ -116,7 +133,7 @@ public class FormFillerTextDemo extends Div {
         DebugTool debugTool = new DebugTool();
 
         ComboBox<String> texts = new ComboBox<>("Select a text or just type your own <br>in the debug Input Source field");
-        texts.setItems("Text1", "Text2");
+        texts.setItems("Text1", "Text2", "Text3");
         texts.setValue("Text1");
         texts.setAllowCustomValue(false);
         debugTool.getDebugInput().setValue(getExampleTexts().get("Text1"));
@@ -143,6 +160,7 @@ public class FormFillerTextDemo extends Div {
                     if (!c.getValue().isEmpty())
                         contextInformation.add(c.getValue());
                 }
+                clearForm();
                 FormFiller formFiller = new FormFiller(formLayout, fieldsInstructions, contextInformation);
                 FormFillerResult result = formFiller.fill(input);
                 debugTool.getDebugPrompt().setValue(result.getRequest());
@@ -171,11 +189,23 @@ public class FormFillerTextDemo extends Div {
 
     }
 
+    private void clearForm() {
+        formLayout.getChildren().forEach(component -> {
+            if (component instanceof HasValue<?, ?>) {
+                ((HasValue) component).clear();
+            } else if (component instanceof Grid) {
+                ((Grid) component).setItems(new ArrayList<>());
+            }
+        });
+    }
+
     public HashMap<String, String> getExampleTexts() {
         HashMap<String, String> texts = new HashMap<>();
         texts.put("Text1", "Order sent by the customer Andrew Jackson on '2023-04-05 12:13:00'\n" +
                 "Address: Ruukinkatu 2-4, FI-20540 Turku, Finland \n" +
                 "Phone Number: 555-1234 \n" +
+                "Age: 43 \n" +
+                "Client ID: 45XXD6543 \n" +
                 "Email: 'andrewjackson@gmail.com \n" +
                 "Due Date: 2023-05-05\n" +
                 "\n" +
@@ -189,10 +219,14 @@ public class FormFillerTextDemo extends Div {
                 "1004    1 Headphones    Hardware    $999    '2023-01-01'    In Transit\n" +
                 "1005    1 Windows License    Software    $1500    '2023-02-01'    Delivered\n" +
                 "\n" +
+                "Taxes: 25,6€ \n" +
+                "Total: 15000€ \n" +
                 "Payment Method: Cash\n");
         texts.put("Text2", "Order sent by the customer Andrew Jackson on '2023-04-05 12:13:00'\n" +
                 "Address: 1234 Elm Street, Springfield, USA \n" +
                 "Phone Number: 555-1234 \n" +
+                "Age: 37 \n" +
+                "Client ID: 45XXD6543 \n" +
                 "Email: 'andrewjackson#gmail.com \n" +
                 "Due Date: 2023-05-05\n" +
                 "\n" +
@@ -205,10 +239,12 @@ public class FormFillerTextDemo extends Div {
                 "1003    5 Wireless Headphones   Hardware    $500    '2023-03-20'    Cancelled\n" +
                 "1004    1 Headphones    Hardware    $999    '2023-01-01'    In Transit\n" +
                 "\n" +
+                "Taxes: 35,6€ \n" +
+                "Total: 10000€ \n" +
                 "Payment Method: Credit Card");
         texts.put("Text3", "This is an invoice of an order for the project 'Vaadin AI Form Filler'" +
-                " providing some hardware and sent by the customer Andrew Jackson who lives at " +
-                "Ruukinkatu 2-4, FI-20540 Turku (Finland) and can be reached at phone number 555-1234 " +
+                " providing some hardware and sent by the customer Andrew Jackson with client id 45XXD6543, who lives at " +
+                "Ruukinkatu 2-4, FI-20540 Turku (Finland), he is 45 years old and can be reached at phone number 555-1234 " +
                 "and at email 'andrewjackson@gmail.com. Andrew has placed five items: number 1001 " +
                 "contains two items of smartphone for a total of $1,000 placed on 2023 January " +
                 "the 10th with a status of deliberate; number 1002 includes one item of laptop " +
@@ -216,7 +252,7 @@ public class FormFillerTextDemo extends Div {
                 "number 1003 consists of five items of wireless headphones for a total of $500 placed " +
                 "on 2023 March the 20th with a status of cancelled; number 1004 is for 'Headphones' " +
                 "with a cost of $999 and placed on '2023-01-01' with status In transit. The invoice " +
-                "was paid using a Paypal account.");
+                "was paid using a Paypal account. The taxes included in the invoice are 40,6€ and Total is 20000€");
         return texts;
     }
 }


### PR DESCRIPTION
## Description

**Changes:**
- Adding fallback to handle all components if those have `HasValue()`, and try to fill them with `setValue(String s)`;
- Adding more meaningful logging, when does not find any components with this log message:
` logger.warn("Component type not supported: {}", componentInfo.component.getClass().getSimpleName());`

Fixes # (issue)
- https://github.com/vaadin/form-filler-addon/issues/40

And improving:
- https://github.com/vaadin/form-filler-addon/issues/49

## Type of change

- [x] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and correct misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
