### PR TITLE
Added log message when a inspected supported field has no id defined

### DIFF
--- a/src/main/java/org/vaadin/addons/ai/formfiller/utils/ComponentUtils.java
+++ b/src/main/java/org/vaadin/addons/ai/formfiller/utils/ComponentUtils.java
@@ -85,6 +85,8 @@ public class ComponentUtils {
     }
     private static void findChildComponents(Component component, List<ComponentInfo> componentInfoList) {
         component.getChildren().forEach(childComponent -> {
+
+
             String componentType = childComponent.getClass().getSimpleName();
             String id = childComponent.getId().orElse(null);
 
@@ -92,6 +94,11 @@ public class ComponentUtils {
                 ComponentInfo info = new ComponentInfo(id, componentType, childComponent);
                 componentInfoList.add(info);
             }
+            else if (isSupportedComponent(childComponent)) {
+                logger.warn("Component of type {} has no id. Remember to add a meaningful" +
+                        " id to the component if you want to fill it with the FromFiller", componentType);
+            }
+
             findChildComponents(childComponent, componentInfoList);
         });
     }
@@ -357,5 +364,30 @@ public class ComponentUtils {
         }).collect(Collectors.toList());
 
         grid.setItems(gridItems);
+    }
+
+    public static boolean isSupportedComponent(Component component) {
+        return supportedComponentStream().anyMatch(c -> c.equals(component.getClass()));
+    }
+
+    private static Stream<Class<? extends Component>> supportedComponentStream() {
+        return Stream.of(
+                TextField.class,
+                TextArea.class,
+                NumberField.class,
+                BigDecimalField.class,
+                IntegerField.class,
+                EmailField.class,
+                PasswordField.class,
+                DatePicker.class,
+                TimePicker.class,
+                DateTimePicker.class,
+                ComboBox.class,
+                Checkbox.class,
+                CheckboxGroup.class,
+                RadioButtonGroup.class,
+                Grid.class,
+                Grid.Column.class
+        );
     }
 }


### PR DESCRIPTION
## Description

When a field inspected (part of the target) has no id defined there is a log message output. To avoid false positive messages with components inside the target that are not meant to be filled there is a new method with supported components. This makes components such as Layouts or RadioButtonItem (internal) not producing false positives. 

Fixes #52 

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [X] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [X] I have added a description following the guideline.
- [X] The issue is created in the corresponding repository and I have referenced it.
- [X] I have added tests to ensure my change is effective and works as intended.
- [X] New and existing tests are passing locally with my change.
- [X] I have performed self-review and corrected misspellings.
- [X] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
