### PR TITLE
Added detailed info when Bean instance creation fails

### DIFF
--- a/src/main/java/org/vaadin/addons/ai/formfiller/utils/ComponentUtils.java
+++ b/src/main/java/org/vaadin/addons/ai/formfiller/utils/ComponentUtils.java
@@ -244,13 +244,13 @@ public class ComponentUtils {
                         continue;
                     }
 
-                    if (componentInfo.component instanceof Grid grid) {
+                    if (componentInfo.component instanceof Grid<?> grid) {
+                        Class<?> beanType = grid.getBeanType();
                         try {
                             List<Map<String, Object>> items = (List<Map<String, Object>>) responseValue;
-                            Class<?> beanType = grid.getBeanType();
                             fillGridWithWildcards(grid, items, beanType);
                         } catch (Exception e) {
-                            logger.error("Error while updating grid with wildcards for bean {} because {}", grid.getBeanType().getSimpleName(), e.getMessage());
+                            logger.error("Error while updating grid with wildcards for bean {} because {}", beanType.getSimpleName(), e.getMessage());
                         }
                     } else if (componentInfo.component instanceof TextField textField) {
                         textField.setValue(responseValue.toString());
@@ -259,7 +259,7 @@ public class ComponentUtils {
                     } else if (componentInfo.component instanceof NumberField numberField) {
                         numberField.setValue(Double.valueOf(responseValue.toString()));
                     } else if (componentInfo.component instanceof BigDecimalField bdField) {
-                        bdField.setValue(BigDecimal.valueOf(Double.valueOf(responseValue.toString())));
+                        bdField.setValue(BigDecimal.valueOf(Double.parseDouble(responseValue.toString())));
                     } else if (componentInfo.component instanceof IntegerField integerField) {
                         integerField.setValue(Integer.valueOf(responseValue.toString()));
                     } else if (componentInfo.component instanceof EmailField emailField) {

--- a/src/main/java/org/vaadin/addons/ai/formfiller/utils/ComponentUtils.java
+++ b/src/main/java/org/vaadin/addons/ai/formfiller/utils/ComponentUtils.java
@@ -237,14 +237,13 @@ public class ComponentUtils {
                         continue;
                     }
 
-                    if (componentInfo.component instanceof Grid) {
+                    if (componentInfo.component instanceof Grid grid) {
                         try {
                             List<Map<String, Object>> items = (List<Map<String, Object>>) responseValue;
-                            Grid<?> grid = (Grid<?>) componentInfo.component;
                             Class<?> beanType = grid.getBeanType();
                             fillGridWithWildcards(grid, items, beanType);
                         } catch (Exception e) {
-                            logger.error("Error while updating grid with wildcards", e.getMessage());
+                            logger.error("Error while updating grid with wildcards for bean {} because {}", grid.getBeanType().getSimpleName(), e.getMessage());
                         }
                     } else if (componentInfo.component instanceof TextField textField) {
                         textField.setValue(responseValue.toString());
@@ -315,7 +314,9 @@ public class ComponentUtils {
             try {
                 item = itemClass.getDeclaredConstructor().newInstance();
             } catch (Exception e) {
-                throw new IllegalStateException("Failed to create a new instance of the item class", e);
+                throw new IllegalStateException("Failed to create a new instance of the Bean class." +
+                        " Please be sure that the Bean has an empty constructor if any non empty" +
+                        " constructor is defined.", e);
             }
 
             for (Map.Entry<String, Object> entry : itemMap.entrySet()) {


### PR DESCRIPTION
## Description

The Bean class used in the grid requires and empty public constructor. So a detailed message has been added when the bean instance creation fails. 

Fixes #55 

## Type of change

- [ ] Bugfix
- [X] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
