### PR TITLE
Improved prompt for ChatGPTService to guarantee correct JSON response (and new constructor was added to FormFiller)

### DIFF
--- a/src/main/java/org/vaadin/addons/ai/formfiller/FormFiller.java
+++ b/src/main/java/org/vaadin/addons/ai/formfiller/FormFiller.java
@@ -105,6 +105,10 @@ public class FormFiller {
         this(target, new HashMap<>(), new ArrayList<>(), new ChatGPTChatCompletionService());
     }
 
+    public FormFiller(Component target, LLMService llmService) {
+        this(target, new HashMap<>(), new ArrayList<>(), llmService);
+    }
+
     /**
      * Fills automatically the target component analyzing the input source
      *

--- a/src/main/java/org/vaadin/addons/ai/formfiller/services/ChatGPTService.java
+++ b/src/main/java/org/vaadin/addons/ai/formfiller/services/ChatGPTService.java
@@ -50,6 +50,7 @@ public class ChatGPTService extends OpenAiService implements LLMService {
                 "Based on the user input: '%s', " +
                         "generate a JSON object according to these instructions: " +
                         "Never include duplicate keys, in case of duplicate keys just keep the first occurrence in the response. " +
+                        "Generate the JSON object with all keys being double quoted." +
                         "Fill out null value in the JSON value if the user did not specify a value. " +
                         "Return the result as a JSON object in this format: '%s'. Perform any modification in the response to assure a valid JSON object."
                 , input, objectMap);


### PR DESCRIPTION
## Description

After DX investigation it was shown that is a problem that ChatGPTService is responding JSON with keys without double quotes. When id contains spaces this ends on a JSON mapping error. 
Also a new constructor has been added to FormFiller with target/LLMservice as it seems convenient after DXs

Fixes #58 

## Type of change

- [X] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
