### PR TITLE
Changed ChatGPTChatCompletionService model to an static model

### DIFF
--- a/src/main/java/org/vaadin/addons/ai/formfiller/services/ChatGPTChatCompletionService.java
+++ b/src/main/java/org/vaadin/addons/ai/formfiller/services/ChatGPTChatCompletionService.java
@@ -17,7 +17,7 @@ public class ChatGPTChatCompletionService extends OpenAiService implements LLMSe
     /**
      * ID of the model to use.
      */
-    private String MODEL = "gpt-3.5-turbo-16k";
+    private String MODEL = "gpt-3.5-turbo-16k-0613";
     /**
      * The maximum number of tokens to generate in the completion.
      */


### PR DESCRIPTION
## Description

Changed model used in ChatGPTChatCompletionService to an static model to avoid unpredictable results when OpenAI updates the models.

Fixes #60 

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
