### PR TITLE
Enabling Jetty hot deploy with `<configuration> <scan>1</scan>...` fr…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>11.0.14</version>
                 <configuration>
-                    <scan>-1</scan>
+                    <scan>1</scan>
                     <!-- Use test scope because the UI/test classes are in
                         the test package. -->
                     <useTestScope>true</useTestScope>


### PR DESCRIPTION
## Description

This change will cause Jetty will check for code changes and if happened, then it will redeploy in 1 sec:
```xml
            <plugin>
                <groupId>org.eclipse.jetty</groupId>
                <artifactId>jetty-maven-plugin</artifactId>
                <version>11.0.14</version>
                <configuration>
                    <scan>1</scan>
                 ...
                </configuration>
  ```                  

The time interval can be increased if we feel it later. 

From documentation:
- https://vaadin.com/docs/latest/configuration/live-reload/jetty
- https://github.com/vaadin/form-filler-addon/issues/48

Fixes # (issue)
- https://github.com/vaadin/form-filler-addon/issues/48
- 
## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
