### PR TITLE
chore: Upgrade gpt version to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,9 +96,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.2</version>
+        </dependency>
+        <dependency>
             <groupId>com.theokanning.openai-gpt3-java</groupId>
             <artifactId>service</artifactId>
-            <version>0.14.0</version>
+            <version>0.15.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Also pins the jackson library to latest version, because gpt has a transitive old dependency on it.