### PR TITLE
fix: removed Column from supported components as id is not longer required for them.

### DIFF
--- a/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
+++ b/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
@@ -392,8 +392,7 @@ public class ComponentUtils {
                 Checkbox.class,
                 CheckboxGroup.class,
                 RadioButtonGroup.class,
-                Grid.class,
-                Grid.Column.class
+                Grid.class
         );
     }
 }


### PR DESCRIPTION
## Description

Column is now managed inside the Grid process without the requirement of setting Ids to be registered in the FormFiller as now FormFiller works with the Bean of the Grid instead of with the columns Ids. 

Fixes #75 
Fixes #2 

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.
