### PR TITLE
feat: added Date support to Grid, now a bean can have a Date field types.

### DIFF
--- a/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
+++ b/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
@@ -19,17 +19,12 @@ import org.slf4j.LoggerFactory;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
+import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.StringJoiner;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -349,6 +344,8 @@ public class ComponentUtils {
                         field.set(item, LocalTime.parse(propValue.toString(), DateTimeFormatter.ofPattern("HH:mm:ss")));
                     else if (field.getType().equals(LocalDateTime.class))
                         field.set(item, LocalDateTime.parse(propValue.toString(), DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")));
+                    else if (field.getType().equals(Date.class))
+                        field.set(item, new SimpleDateFormat("yyyy-MM-dd").parse(propValue.toString()));
                     else if (field.getType().equals(Double.class))
                         field.set(item, Double.valueOf(propValue.toString()));
                     else if (field.getType().equals(Integer.class))

--- a/src/test/java/com/vaadin/flow/ai/formfiller/data/OrderItem.java
+++ b/src/test/java/com/vaadin/flow/ai/formfiller/data/OrderItem.java
@@ -1,11 +1,13 @@
 package com.vaadin.flow.ai.formfiller.data;
 
 import java.time.LocalDate;
+import java.util.Date;
 
 public class OrderItem {
     private String orderId;
     private String itemName;
     private LocalDate orderDate;
+    private Date deliveryDate;
     private String orderStatus;
     private Double orderCost;
 
@@ -31,6 +33,14 @@ public class OrderItem {
 
     public void setOrderStatus(String orderStatus) {
         this.orderStatus = orderStatus;
+    }
+
+    public void setDeliveryDate(Date deliveryDate) {
+        this.deliveryDate = deliveryDate;
+    }
+
+    public Date getDeliveryDate() {
+        return deliveryDate;
     }
 
     public Double getOrderTotal() {

--- a/src/test/java/com/vaadin/flow/ai/formfiller/utils/Converters.java
+++ b/src/test/java/com/vaadin/flow/ai/formfiller/utils/Converters.java
@@ -1,0 +1,16 @@
+package com.vaadin.flow.ai.formfiller.utils;
+
+import com.vaadin.flow.function.SerializableFunction;
+
+import java.time.LocalDate;
+import java.util.Date;
+
+public class Converters {
+
+    public static SerializableFunction<Date, LocalDate> dateToLocalDate() {
+        return date -> date == null ? null : new java.sql.Date(date.getTime()).toLocalDate();
+    }
+    public static SerializableFunction<LocalDate, Date> localDateToDate() {
+        return localDate -> localDate == null ? null : java.sql.Date.valueOf(localDate);
+    }
+}

--- a/src/test/java/com/vaadin/flow/ai/formfiller/views/FormFillerTextDemo.java
+++ b/src/test/java/com/vaadin/flow/ai/formfiller/views/FormFillerTextDemo.java
@@ -119,6 +119,7 @@ public class FormFillerTextDemo extends Div {
         orderGrid.getColumnByKey("orderId").setHeader("Id");
         orderGrid.getColumnByKey("itemName").setHeader("Name");
         orderGrid.getColumnByKey("orderDate").setHeader("Date");
+        orderGrid.getColumnByKey("deliveryDate").setHeader("Delivery Date");
         orderGrid.getColumnByKey("orderStatus").setHeader("Status");
         orderGrid.getColumnByKey("orderTotal").setHeader("Cost");
 
@@ -268,12 +269,12 @@ public class FormFillerTextDemo extends Div {
                 "This order contains the products for the project 'Form filler AI Addon' that is part of the new development of Vaadin AI kit. \n" +
                 "\n" +
                 "Items list:\n" +
-                "Item Number     Items   Type    Cost    Date    Status\n" +
-                "1001    2 Smartphones   Hardware    $1000   '2023-01-10' Delivered\n" +
-                "1002    1 Laptop    Hardware    $1500   '2023-02-15'    In Transit\n" +
-                "1003    5 Wireless Headphones   Hardware    $500    '2023-03-20'    Cancelled\n" +
-                "1004    1 Headphones    Hardware    $999    '2023-01-01'    In Transit\n" +
-                "1005    1 Windows License    Software    $1500    '2023-02-01'    Delivered\n" +
+                "Item Number     Items   Type    Cost    Date    Delivery Date    Status\n" +
+                "1001    2 Smartphones   Hardware    $1000   '2023-01-10'    '2023-01-13'    Delivered\n" +
+                "1002    1 Laptop    Hardware    $1500   '2023-02-15'    '2023-01-15'    In Transit\n" +
+                "1003    5 Wireless Headphones   Hardware    $500    '2023-03-20'    '2023-01-14'    Cancelled\n" +
+                "1004    1 Headphones    Hardware    $999    '2023-01-01'    '2023-01-15'    In Transit\n" +
+                "1005    1 Windows License    Software    $1500    '2023-02-01'    '2023-01-16'    Delivered\n" +
                 "\n" +
                 "Taxes: 25,6€ \n" +
                 "Total: 15000€ \n" +

--- a/src/test/java/com/vaadin/flow/ai/formfiller/views/FormFillerTextDemo.java
+++ b/src/test/java/com/vaadin/flow/ai/formfiller/views/FormFillerTextDemo.java
@@ -1,5 +1,6 @@
 package com.vaadin.flow.ai.formfiller.views;
 
+import com.vaadin.flow.ai.formfiller.utils.Converters;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.button.Button;
@@ -13,6 +14,7 @@ import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.editor.Editor;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
@@ -24,6 +26,8 @@ import com.vaadin.flow.component.textfield.PasswordField;
 import com.vaadin.flow.component.textfield.TextArea;
 import com.vaadin.flow.component.textfield.TextField;
 import com.vaadin.flow.data.binder.Binder;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.function.ValueProvider;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.ai.formfiller.FormFiller;
 import com.vaadin.flow.ai.formfiller.FormFillerResult;
@@ -33,7 +37,10 @@ import com.vaadin.flow.ai.formfiller.utils.ComponentUtils;
 import com.vaadin.flow.ai.formfiller.utils.DebugTool;
 import com.vaadin.flow.ai.formfiller.utils.ExtraInstructionsTool;
 
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 
 @Route("")
@@ -119,7 +126,12 @@ public class FormFillerTextDemo extends Div {
         orderGrid.getColumnByKey("orderId").setHeader("Id");
         orderGrid.getColumnByKey("itemName").setHeader("Name");
         orderGrid.getColumnByKey("orderDate").setHeader("Date");
-        orderGrid.getColumnByKey("deliveryDate").setHeader("Delivery Date");
+        orderGrid.getColumnByKey("deliveryDate").setHeader("Delivery Date")
+                .setRenderer(new ComponentRenderer<>(orderItem -> {
+                    SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+                    // Format the date using the SimpleDateFormat
+                    return new Span(dateFormat.format(orderItem.getDeliveryDate()));
+                }));
         orderGrid.getColumnByKey("orderStatus").setHeader("Status");
         orderGrid.getColumnByKey("orderTotal").setHeader("Cost");
 
@@ -159,6 +171,13 @@ public class FormFillerTextDemo extends Div {
         binder.forField(edDateField).bind(OrderItem::getOrderDate,
                 OrderItem::setOrderDate);
         orderGrid.getColumnByKey("orderDate").setEditorComponent(edDateField);
+
+        DatePicker edDeliveryDateField = new DatePicker();
+        edDeliveryDateField.setWidthFull();
+        binder.forField(edDeliveryDateField)
+                .withConverter(Converters.localDateToDate(), Converters.dateToLocalDate())
+                .bind(OrderItem::getDeliveryDate, OrderItem::setDeliveryDate);
+        orderGrid.getColumnByKey("deliveryDate").setEditorComponent(edDeliveryDateField);
 
         TextField edStatusItemField = new TextField();
         edStatusItemField.setWidthFull();


### PR DESCRIPTION
## Description

**Changes:**
- Added Date field to OrderItem,
- Added checking and parsing it to ComponentUtils,
- And added an example to FormFillerTextDemo,

Fixes # (issue)
- https://github.com/vaadin/form-filler-addon/issues/51

<img width="1430" alt="image" src="https://github.com/vaadin/form-filler-addon/assets/61667986/c761bce9-83c3-4e03-a001-8191d9398835">

<img width="1437" alt="image" src="https://github.com/vaadin/form-filler-addon/assets/61667986/3116fcd3-07a6-459e-abd2-6f91e4c9ecb5">


## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
