### PR TITLE
feat: make MultiSelectCombobox supported for the form filler.

### DIFF
--- a/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
+++ b/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
@@ -176,19 +176,21 @@ public class ComponentUtils {
                 } else if ((componentInfo.component instanceof ComboBox<?>)) {
                     StringJoiner joiner = new StringJoiner("\" OR \"");
                     ((ComboBox<String>) componentInfo.component).getListDataView().getItems().forEach(joiner::add);
-                    inputFieldMap.put(componentInfo.id, "a String from one of these options \"" + joiner.toString() + "\"");
+                    inputFieldMap.put(componentInfo.id, "a String from one of these options \"" + joiner + "\"");
                 } else if (componentInfo.component instanceof MultiSelectComboBox) {
-                    inputFieldMap.put(componentInfo.id, "a String");
+                    StringJoiner joiner = new StringJoiner("\", \"");
+                    ((MultiSelectComboBox<String>) componentInfo.component).getListDataView().getItems().forEach(joiner::add);
+                    inputFieldMap.put(componentInfo.id, "a Set of Strings selecting none, one or more of these options  \"" + joiner + "\"");
                 } else if ((componentInfo.component instanceof Checkbox)) {
                     inputFieldMap.put(componentInfo.id, "a Boolean");
                 } else if ((componentInfo.component instanceof CheckboxGroup<?>)) {
                     StringJoiner joiner = new StringJoiner("\", \"");
                     ((CheckboxGroup<String>) componentInfo.component).getListDataView().getItems().forEach(joiner::add);
-                    inputFieldMap.put(componentInfo.id, "a Set of Strings selecting none, one or more of these options  \"" + joiner.toString() + "\"");
+                    inputFieldMap.put(componentInfo.id, "a Set of Strings selecting none, one or more of these options  \"" + joiner + "\"");
                 } else if ((componentInfo.component instanceof RadioButtonGroup<?>)) {
                     StringJoiner joiner = new StringJoiner("\" OR \"");
                     ((RadioButtonGroup<String>) componentInfo.component).getListDataView().getItems().forEach(joiner::add);
-                    inputFieldMap.put(componentInfo.id, "a String from one of these options \"" + joiner.toString() + "\"");
+                    inputFieldMap.put(componentInfo.id, "a String from one of these options \"" + joiner + "\"");
                 } else if (componentInfo.component instanceof Grid.Column<?>) {
                     // Nothing to do as columns are managed in the Grid case
                 } else if (componentInfo.component instanceof Grid<?>) {
@@ -282,8 +284,15 @@ public class ComponentUtils {
                         datetimePicker.setValue(LocalDateTime.parse(responseValue.toString()));
                     } else if (componentInfo.component instanceof ComboBox comboBox) {
                         comboBox.setValue(responseValue);
-                    } else if (componentInfo.component instanceof MultiSelectComboBox multiSelectComboBox) {
-                        multiSelectComboBox.setValue(responseValue);
+                    } else if (componentInfo.component instanceof MultiSelectComboBox<?>) {
+                        MultiSelectComboBox<String> multiSelectComboBox = (MultiSelectComboBox<String>) componentInfo.component;
+                        try {
+                            ArrayList<String> list = (ArrayList<String>) responseValue;
+                            Set<String> set = new HashSet<>(list);
+                            multiSelectComboBox.setValue(set);
+                        } catch (Exception e) {
+                            logger.error("Error while updating multiSelectComboBox with id: {}", id, e);
+                        }
                     } else if (componentInfo.component instanceof Checkbox) {
                         Checkbox checkbox = (Checkbox) componentInfo.component;
                         checkbox.setValue((Boolean) responseValue);
@@ -291,7 +300,7 @@ public class ComponentUtils {
                         CheckboxGroup<String> checkboxgroup = (CheckboxGroup<String>) componentInfo.component;
                         try {
                             ArrayList<String> list = (ArrayList<String>) responseValue;
-                            Set<String> set = new HashSet<String>(list);
+                            Set<String> set = new HashSet<>(list);
                             checkboxgroup.setValue(set);
                         } catch (Exception e) {
                             logger.error("Error while updating checkboxgroup with id: {}", id, e);

--- a/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
+++ b/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
@@ -392,8 +392,7 @@ public class ComponentUtils {
                 Checkbox.class,
                 CheckboxGroup.class,
                 RadioButtonGroup.class,
-                Grid.class,
-                Grid.Column.class
+                Grid.class
         );
     }
 }

--- a/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
+++ b/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
@@ -401,7 +401,8 @@ public class ComponentUtils {
                 Checkbox.class,
                 CheckboxGroup.class,
                 RadioButtonGroup.class,
-                Grid.class
+                Grid.class,
+                MultiSelectComboBox.class
         );
     }
 }

--- a/src/test/java/com/vaadin/flow/ai/formfiller/views/FormFillerTextDemo.java
+++ b/src/test/java/com/vaadin/flow/ai/formfiller/views/FormFillerTextDemo.java
@@ -230,7 +230,8 @@ public class FormFillerTextDemo extends Div {
         extraInstructionsTool.setVisible(false);
         extraInstructionsTool.setExtraInstructions(nameField, "Format this field in Uppercase");
         extraInstructionsTool.setExtraInstructions(emailField, "Format this field as a correct email");
-        extraInstructionsTool.setContextInstructions(0,"Translate item names to Spanish");
+        extraInstructionsTool.setExtraInstructions(typeService, "This field describes the type of the items of the order");
+        extraInstructionsTool.setContextInstructions(0,"Translate item names of the order to Spanish");
 
         Button extraInstructionsButton = new Button("Show/Hide extra instructions");
         extraInstructionsButton.addThemeVariants(ButtonVariant.LUMO_ERROR);

--- a/src/test/java/com/vaadin/flow/ai/formfiller/views/FormFillerTextDemo.java
+++ b/src/test/java/com/vaadin/flow/ai/formfiller/views/FormFillerTextDemo.java
@@ -7,6 +7,7 @@ import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.checkbox.CheckboxGroup;
 import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
 import com.vaadin.flow.component.datepicker.DatePicker;
 import com.vaadin.flow.component.datetimepicker.DateTimePicker;
 import com.vaadin.flow.component.formlayout.FormLayout;
@@ -108,6 +109,11 @@ public class FormFillerTextDemo extends Div {
         typeService.setItems("Software", "Hardware", "Consultancy");
         typeService.setId("typeService");
         formLayout.add(typeService);
+
+        MultiSelectComboBox<String> typeServiceMulti = new MultiSelectComboBox<>("Type of Service");
+        typeServiceMulti.setItems("Software", "Hardware", "Consultancy");
+        typeServiceMulti.setId("typeServiceMs");
+        formLayout.add(typeServiceMulti);
 
         // To make the grid supported by FormFiller it is necessary to set an ID
         // and a Bean class to the Grid.
@@ -231,6 +237,7 @@ public class FormFillerTextDemo extends Div {
         extraInstructionsTool.setExtraInstructions(nameField, "Format this field in Uppercase");
         extraInstructionsTool.setExtraInstructions(emailField, "Format this field as a correct email");
         extraInstructionsTool.setExtraInstructions(typeService, "This field describes the type of the items of the order");
+        extraInstructionsTool.setExtraInstructions(typeServiceMulti, "This field describes the type of the items of the order");
         extraInstructionsTool.setContextInstructions(0,"Translate item names of the order to Spanish");
 
         Button extraInstructionsButton = new Button("Show/Hide extra instructions");


### PR DESCRIPTION
## Description
Reviewed and fixed the multi-select combobox to make it possible to fill it with the auto filler.

Fixes # (issue)
- https://github.com/vaadin/form-filler-addon/issues/53

![image](https://github.com/vaadin/form-filler-addon/assets/61667986/4dd1a660-3afd-49cb-a99f-dd496e17c974)



**Changes:**
- Based on the checkboxgroup rewritten, updated the code (instruction and filling)
- Added example as well to the FormFillerTextDemo class (same example as RadioButton group, so the services)

**Also:**
- `joiner.toString()` -> `joiner` as it is not needed for the String concatenation.
- `Set<String> set = new HashSet<String>(list);` ->  `Set<String> set = new HashSet<>(list);`



## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
