### PR TITLE
chore: changing vaadin-core dependency to have provided scope.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.9</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
             <groupId>com.vaadin</groupId>
             <!-- Consider limiting the dependencies to flow-server only something, but for most end users depending on vaadin-core is ok -->
             <artifactId>vaadin-core</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
## Description
Based on Marc's problem:
```
Failed to collect dependencies at com.vaadin.flow.ai:form-filler-addon:jar:0.1.0: Failed to read artifact descriptor for com.vaadin.flow.ai:form-filler-addon:jar:0.1.0: Could not find artifact com.vaadin:vaadin-bom:pom:24.1-SNAPSHOT
```

and Artur's recommended way to handle Vaadin versions.

This will solve the problem, when a developer is adding the `form-filler-addon` dependency to a maven project and having a specific `vaadin-core` version, now with this, the version should come from the project the addon dependency is used.

Fixes # (issue):
- https://github.com/vaadin/form-filler-addon/issues/122

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
