### PR TITLE
update vaadin-parent to 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.vaadin</groupId>
         <artifactId>vaadin-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.2.0</version>
     </parent>
 
     <groupId>com.vaadin.flow.ai</groupId>
@@ -66,6 +66,10 @@
         <repository>
             <id>Vaadin Directory</id>
             <url>https://maven.vaadin.com/vaadin-addons</url>
+        </repository>
+        <repository>
+            <id>Staged Repo</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/comvaadin-2172</url>
         </repository>
     </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,10 +67,6 @@
             <id>Vaadin Directory</id>
             <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
-        <repository>
-            <id>Staged Repo</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/comvaadin-2172</url>
-        </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
this allow us to do the prerelease update dropping the staging feature