### PR TITLE
fix: add the development profile, which is required to access the demo URLs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,8 +316,10 @@ In these examples we use snapshots from 1 page documents to get the text. In bot
 
 Starting the test/demo server:
 ```
-mvn jetty:run
+ mvn jetty:run -Pdevelopment
 ```
+
+Hint: you need to use the development profile, because it will include the vaadin-server and so the below URL-s will be reachable. Otherwise, the dependency will be provided and Vaadin URL-s will not be loaded.
 
 This deploys demos at http://localhost:8080, http://localhost:8080/receipt and http://localhost:8080/invoice
  

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Starting the test/demo server:
  mvn jetty:run -Pdevelopment
 ```
 
-Hint: you need to use the development profile, because it will include the vaadin-server and so the below URL-s will be reachable. Otherwise, the dependency will be provided and Vaadin URL-s will not be loaded.
+Hint: Ensure you activate the development profile. This includes the vaadin-server, making the URLs below accessible. Without this profile, the dependency remains in the provided scope, and the Vaadin demo URL paths won't load or be reachable.
 
 This deploys demos at http://localhost:8080, http://localhost:8080/receipt and http://localhost:8080/invoice
  

--- a/pom.xml
+++ b/pom.xml
@@ -235,6 +235,17 @@
 
     <profiles>
         <profile>
+            <id>development</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.vaadin</groupId>
+                    <!-- Consider limiting the dependencies to flow-server only something, but for most end users depending on vaadin-core is ok -->
+                    <artifactId>vaadin-core</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
             <!-- Production mode is activated using -Pproduction -->
             <id>production</id>
             <properties>


### PR DESCRIPTION
## Description

Adding a development profile which should be used in order to properly run the addon project with reachable demos:
- http://localhost:8080, 
- http://localhost:8080/receipt 
- http://localhost:8080/invoice
 
The proper mvn command:
```
mvn jetty:run -Pdevelopment
```

Otherwise if no development used then only Jetty context is reachable:
<img width="848" alt="image" src="https://github.com/vaadin/form-filler-addon/assets/61667986/2080f399-eefd-4350-8ef1-d176a57e9ece">

Server logs quite empty, no Vaadin server related load there:
```
...
[WARNING] jakarta.servlet.http.WebConnection scanned from multiple locations: jar:file:///Users/pczuczor/.m2/repository/org/eclipse/jetty/toolchain/jetty-jakarta-servlet-api/5.0.2/jetty-jakarta-servlet-api-5.0.2.jar!/jakarta/servlet/http/WebConnection.class, jar:file:///Users/pczuczor/.m2/repository/jakarta/servlet/jakarta.servlet-api/5.0.0/jakarta.servlet-api-5.0.0.jar!/jakarta/servlet/http/WebConnection.class
[INFO] Session workerName=node0
[INFO] Started o.e.j.m.p.MavenWebAppContext@5333f08f{/,[file:///Users/pczuczor/Projects/form-filler-addon/target/webapp-synth/, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/vaadin-cookie-consent-flow/24.2-SNAPSHOT/vaadin-cookie-consent-flow-24.2-SNAPSHOT.jar!/META-INF/resources],AVAILABLE}{file:///Users/pczuczor/Projects/form-filler-addon/target/webapp-synth/}
[INFO] Started ServerConnector@4f581211{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
[INFO] Started Server@75bd28d{STARTING}[11.0.15,sto=0] @3955ms
[INFO] Scan interval sec = 1
```

But with `mvn jetty:run -Pdevelopment` command and with this change it will be:
```
...
[WARNING] jakarta.servlet.http.WebConnection scanned from multiple locations: jar:file:///Users/pczuczor/.m2/repository/org/eclipse/jetty/toolchain/jetty-jakarta-servlet-api/5.0.2/jetty-jakarta-servlet-api-5.0.2.jar!/jakarta/servlet/http/WebConnection.class, jar:file:///Users/pczuczor/.m2/repository/jakarta/servlet/jakarta.servlet-api/5.0.0/jakarta.servlet-api-5.0.0.jar!/jakarta/servlet/http/WebConnection.class
[main] INFO com.vaadin.base.devserver.startup.DevModeStartupListener - Starting dev-mode updaters in /Users/pczuczor/Projects/form-filler-addon folder.
[main] INFO com.vaadin.flow.server.frontend.scanner.FullDependenciesScanner - Visited 98 classes. Took 21 ms.
[main] INFO com.vaadin.flow.server.frontend.BundleValidationUtil - Checking if a development mode bundle build is needed
[main] INFO com.vaadin.flow.server.frontend.BundleValidationUtil - A development mode bundle build is not needed
[ForkJoinPool.commonPool-worker-4] INFO com.vaadin.flow.server.frontend.TaskCopyFrontendFiles - Copying frontend resources from jar files ...
[ForkJoinPool.commonPool-worker-4] INFO com.vaadin.flow.server.frontend.TaskCopyFrontendFiles - Visited 18 resources. Took 23 ms.
[INFO] Initializing AtmosphereFramework
[INFO] Session workerName=node0
Vaadin application has been deployed and started to the context path "/".
[main] INFO com.vaadin.flow.server.startup.ServletDeployer - Automatically deploying Vaadin servlet with name com.vaadin.flow.server.startup.ServletDeployer to /*
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Installed AtmosphereHandler com.vaadin.flow.server.communication.PushAtmosphereHandler mapped to context-path: /*
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Installed the following AtmosphereInterceptor mapped to AtmosphereHandler com.vaadin.flow.server.communication.PushAtmosphereHandler
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Atmosphere is using org.atmosphere.util.VoidAnnotationProcessor for processing annotation
[main] INFO org.atmosphere.util.ForkJoinPool - Using ForkJoinPool  java.util.concurrent.ForkJoinPool. Set the org.atmosphere.cpr.broadcaster.maxAsyncWriteThreads to -1 to fully use its power.
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Installed WebSocketProtocol org.atmosphere.websocket.protocol.SimpleHttpProtocol 
[main] INFO org.atmosphere.container.JSR356AsyncSupport - JSR 356 Mapping path /VAADIN/push
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Installing Default AtmosphereInterceptors
[main] INFO org.atmosphere.cpr.AtmosphereFramework - 	org.atmosphere.interceptor.CorsInterceptor : CORS Interceptor Support
[main] INFO org.atmosphere.cpr.AtmosphereFramework - 	org.atmosphere.interceptor.CacheHeadersInterceptor : Default Response's Headers Interceptor
[main] INFO org.atmosphere.cpr.AtmosphereFramework - 	org.atmosphere.interceptor.PaddingAtmosphereInterceptor : Browser Padding Interceptor Support
[main] INFO org.atmosphere.cpr.AtmosphereFramework - 	org.atmosphere.interceptor.AndroidAtmosphereInterceptor : Android Interceptor Support
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Dropping Interceptor org.atmosphere.interceptor.HeartbeatInterceptor
[main] INFO org.atmosphere.cpr.AtmosphereFramework - 	org.atmosphere.interceptor.SSEAtmosphereInterceptor : SSE Interceptor Support
[main] INFO org.atmosphere.cpr.AtmosphereFramework - 	org.atmosphere.interceptor.JSONPAtmosphereInterceptor : JSONP Interceptor Support
[main] INFO org.atmosphere.cpr.AtmosphereFramework - 	org.atmosphere.interceptor.JavaScriptProtocol : Atmosphere JavaScript Protocol
[main] INFO org.atmosphere.cpr.AtmosphereFramework - 	org.atmosphere.interceptor.WebSocketMessageSuspendInterceptor : org.atmosphere.interceptor.WebSocketMessageSuspendInterceptor
[main] INFO org.atmosphere.cpr.AtmosphereFramework - 	org.atmosphere.interceptor.OnDisconnectInterceptor : Browser disconnection detection
[main] INFO org.atmosphere.cpr.AtmosphereFramework - 	org.atmosphere.interceptor.IdleResourceInterceptor : org.atmosphere.interceptor.IdleResourceInterceptor
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Set org.atmosphere.cpr.AtmosphereInterceptor.disableDefaults to disable them.
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Installed AtmosphereInterceptor CORS Interceptor Support with priority FIRST_BEFORE_DEFAULT 
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Installed AtmosphereInterceptor Default Response's Headers Interceptor with priority AFTER_DEFAULT 
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Installed AtmosphereInterceptor Browser Padding Interceptor Support with priority AFTER_DEFAULT 
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Installed AtmosphereInterceptor Android Interceptor Support with priority AFTER_DEFAULT 
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Installed AtmosphereInterceptor SSE Interceptor Support with priority AFTER_DEFAULT 
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Installed AtmosphereInterceptor JSONP Interceptor Support with priority AFTER_DEFAULT 
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Installed AtmosphereInterceptor Atmosphere JavaScript Protocol with priority AFTER_DEFAULT 
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Installed AtmosphereInterceptor org.atmosphere.interceptor.WebSocketMessageSuspendInterceptor with priority AFTER_DEFAULT 
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Installed AtmosphereInterceptor Browser disconnection detection with priority AFTER_DEFAULT 
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Installed AtmosphereInterceptor org.atmosphere.interceptor.IdleResourceInterceptor with priority BEFORE_DEFAULT 
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Using EndpointMapper class org.atmosphere.util.DefaultEndpointMapper
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Using BroadcasterCache: org.atmosphere.cache.UUIDBroadcasterCache
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Default Broadcaster Class: org.atmosphere.cpr.DefaultBroadcaster
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Broadcaster Shared List Resources: false
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Broadcaster Polling Wait Time 100
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Shared ExecutorService supported: true
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Messaging ExecutorService Pool Size unavailable - Not instance of ThreadPoolExecutor
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Async I/O Thread Pool Size: 200
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Using BroadcasterFactory: org.atmosphere.cpr.DefaultBroadcasterFactory
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Using AtmosphereResurceFactory: org.atmosphere.cpr.DefaultAtmosphereResourceFactory
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Using WebSocketProcessor: org.atmosphere.websocket.DefaultWebSocketProcessor
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Invoke AtmosphereInterceptor on WebSocket message true
[main] INFO org.atmosphere.cpr.AtmosphereFramework - HttpSession supported: true
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Atmosphere is using DefaultAtmosphereObjectFactory for dependency injection and object creation
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Atmosphere is using async support: org.atmosphere.container.JSR356AsyncSupport running under container: jetty/11.0.15 using jakarta.servlet/3.0 and jsr356/WebSocket API
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Atmosphere Framework 3.0.3.slf4jvaadin1 started.
[main] INFO org.atmosphere.cpr.AtmosphereFramework - Installed AtmosphereInterceptor  Track Message Size Interceptor using | with priority BEFORE_DEFAULT 
[main] INFO com.vaadin.flow.server.DefaultDeploymentConfiguration - 
Vaadin is running in DEVELOPMENT mode - do not use for production deployments.

The following feature previews are enabled:
- Form Filler Add-on


[INFO] Started o.e.j.m.p.MavenWebAppContext@1c92a549{/,[file:///Users/pczuczor/Projects/form-filler-addon/target/webapp-synth/, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/vaadin-grid-flow/24.2-SNAPSHOT/vaadin-grid-flow-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/vaadin-context-menu-flow/24.2-SNAPSHOT/vaadin-context-menu-flow-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/vaadin-flow-components-base/24.2-SNAPSHOT/vaadin-flow-components-base-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/vaadin-menu-bar-flow/24.2-SNAPSHOT/vaadin-menu-bar-flow-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/vaadin-text-field-flow/24.2-SNAPSHOT/vaadin-text-field-flow-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/vaadin-combo-box-flow/24.2-SNAPSHOT/vaadin-combo-box-flow-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/vaadin-cookie-consent-flow/24.2-SNAPSHOT/vaadin-cookie-consent-flow-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/flow-client/24.2-SNAPSHOT/flow-client-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/flow-dnd/24.2-SNAPSHOT/flow-dnd-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/vaadin-button-flow/24.2-SNAPSHOT/vaadin-button-flow-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/vaadin-renderer-flow/24.2-SNAPSHOT/vaadin-renderer-flow-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/vaadin-select-flow/24.2-SNAPSHOT/vaadin-select-flow-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/flow-push/24.2-SNAPSHOT/flow-push-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/vaadin-time-picker-flow/24.2-SNAPSHOT/vaadin-time-picker-flow-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/vaadin-messages-flow/24.2-SNAPSHOT/vaadin-messages-flow-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/vaadin-date-picker-flow/24.2-SNAPSHOT/vaadin-date-picker-flow-24.2-SNAPSHOT.jar!/META-INF/resources, jar:file:///Users/pczuczor/.m2/repository/com/vaadin/vaadin-virtual-list-flow/24.2-SNAPSHOT/vaadin-virtual-list-flow-24.2-SNAPSHOT.jar!/META-INF/resources],AVAILABLE}{file:///Users/pczuczor/Projects/form-filler-addon/target/webapp-synth/}
[INFO] Started ServerConnector@256d8f17{HTTP/1.1, (http/1.1)}{0.0.0.0:8080}
[INFO] Started Server@5d2e6f62{STARTING}[11.0.15,sto=0] @8312ms
[INFO] Scan interval sec = 1

```

Fixes # (issue)
Part of this problem:
- https://github.com/vaadin/form-filler-addon/issues/122

A fix for this PR change:
- https://github.com/vaadin/form-filler-addon/pull/123


## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
