### PR TITLE
fix: filling values for ComboBoxes and MultiSelectComboboxes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,11 @@
             <artifactId>slf4j-api</artifactId>
             <version>2.0.9</version>
         </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>vaadin-testbench-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
+++ b/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
@@ -281,7 +281,7 @@ public class ComponentUtils {
                         if (comboBox.isAllowCustomValue()) {
                             comboBox.setValue(responseValue);
                         } else {
-                            Stream items = comboBox.getListDataView().getItems();
+                            Stream items = comboBox.getGenericDataView().getItems();
                             if (items.toList().contains(responseValue)) {
                                 comboBox.setValue(responseValue);
                             }
@@ -297,7 +297,7 @@ public class ComponentUtils {
                             } else {
                                 multiSelectComboBox.setValue(set
                                         .stream()
-                                        .filter(multiSelectComboBox.getListDataView().getItems().toList()::contains)
+                                        .filter(multiSelectComboBox.getGenericDataView().getItems().toList()::contains)
                                         .collect(Collectors.toSet()));
                             }
                         } catch (Exception e) {

--- a/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
+++ b/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
@@ -295,8 +295,10 @@ public class ComponentUtils {
                             if (multiSelectComboBox.isAllowCustomValue()) {
                                 multiSelectComboBox.setValue(set);
                             } else {
-                                multiSelectComboBox.setValue(set.stream().filter(multiSelectComboBox.getListDataView().getItems().toList()::contains).collect(Collectors.toSet()));
-                                multiSelectComboBox.setValue(set);
+                                multiSelectComboBox.setValue(set
+                                        .stream()
+                                        .filter(multiSelectComboBox.getListDataView().getItems().toList()::contains)
+                                        .collect(Collectors.toSet()));
                             }
                         } catch (Exception e) {
                             logger.error("Error while updating multiSelectComboBox with id: {}", id, e);

--- a/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
+++ b/src/main/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtils.java
@@ -13,6 +13,7 @@ import com.vaadin.flow.component.listbox.MultiSelectListBox;
 import com.vaadin.flow.component.radiobutton.RadioButtonGroup;
 import com.vaadin.flow.component.textfield.*;
 import com.vaadin.flow.component.timepicker.TimePicker;
+import com.vaadin.flow.data.provider.ListDataProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -277,13 +278,26 @@ public class ComponentUtils {
                     } else if (componentInfo.component instanceof DateTimePicker datetimePicker) {
                         datetimePicker.setValue(LocalDateTime.parse(responseValue.toString()));
                     } else if (componentInfo.component instanceof ComboBox comboBox) {
-                        comboBox.setValue(responseValue);
+                        if (comboBox.isAllowCustomValue()) {
+                            comboBox.setValue(responseValue);
+                        } else {
+                            Stream items = comboBox.getListDataView().getItems();
+                            if (items.toList().contains(responseValue)) {
+                                comboBox.setValue(responseValue);
+                            }
+                        }
+
                     } else if (componentInfo.component instanceof MultiSelectComboBox<?>) {
                         MultiSelectComboBox<String> multiSelectComboBox = (MultiSelectComboBox<String>) componentInfo.component;
                         try {
                             ArrayList<String> list = (ArrayList<String>) responseValue;
                             Set<String> set = new HashSet<>(list);
-                            multiSelectComboBox.setValue(set);
+                            if (multiSelectComboBox.isAllowCustomValue()) {
+                                multiSelectComboBox.setValue(set);
+                            } else {
+                                multiSelectComboBox.setValue(set.stream().filter(multiSelectComboBox.getListDataView().getItems().toList()::contains).collect(Collectors.toSet()));
+                                multiSelectComboBox.setValue(set);
+                            }
                         } catch (Exception e) {
                             logger.error("Error while updating multiSelectComboBox with id: {}", id, e);
                         }

--- a/src/test/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtilsTest.java
+++ b/src/test/java/com/vaadin/flow/ai/formfiller/utils/ComponentUtilsTest.java
@@ -1,0 +1,296 @@
+package com.vaadin.flow.ai.formfiller.utils;
+
+import com.vaadin.flow.component.combobox.ComboBox;
+import com.vaadin.flow.component.combobox.MultiSelectComboBox;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ComponentUtilsTest {
+    @Test
+    public void testComboBoxFillItemInItemListCustomValueNotAllowed() {
+        //create ComponentInfo
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setId("food");
+        comboBox.setItems("pizza", "pasta", "salad");
+
+        ComponentUtils.ComponentInfo componentInfo =
+                new ComponentUtils.ComponentInfo("food", "ComboBox", comboBox);
+
+        //create AI response
+        Map<String, Object> response = new HashMap<>();
+        response.put("food", "pizza");
+
+        //fill component
+        ComponentUtils.fillComponents(List.of(componentInfo), response);
+        assertEquals("pizza", comboBox.getValue());
+    }
+
+    @Test
+    public void testComboBoxFillItemInItemListCustomValueAllowed() {
+        //create ComponentInfo
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setId("food");
+        comboBox.setItems("pizza", "pasta", "salad");
+        comboBox.setAllowCustomValue(true);
+
+        ComponentUtils.ComponentInfo componentInfo =
+                new ComponentUtils.ComponentInfo("food", "ComboBox", comboBox);
+
+        //create AI response
+        Map<String, Object> response = new HashMap<>();
+        response.put("food", "pizza");
+
+        //fill component
+        ComponentUtils.fillComponents(List.of(componentInfo), response);
+        assertEquals("pizza", comboBox.getValue());
+    }
+
+    @Test
+    public void testComboBoxFillItemNotInItemListCustomValueNotAllowed() {
+        //create ComponentInfo
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setId("food");
+        comboBox.setItems("pizza", "pasta", "salad");
+
+        ComponentUtils.ComponentInfo componentInfo =
+                new ComponentUtils.ComponentInfo("food", "ComboBox", comboBox);
+
+        //create AI response
+        Map<String, Object> response = new HashMap<>();
+        response.put("food", "hamburger");
+
+        //fill component
+        ComponentUtils.fillComponents(List.of(componentInfo), response);
+        assertNull(comboBox.getValue());
+    }
+
+    @Test
+    public void testComboBoxFillItemNotInItemListCustomValueAllowed() {
+        //create ComponentInfo
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setId("food");
+        comboBox.setItems("pizza", "pasta", "salad");
+        comboBox.setAllowCustomValue(true);
+
+        ComponentUtils.ComponentInfo componentInfo =
+                new ComponentUtils.ComponentInfo("food", "ComboBox", comboBox);
+
+        //create AI response
+        Map<String, Object> response = new HashMap<>();
+        response.put("food", "hamburger");
+
+        //fill component
+        ComponentUtils.fillComponents(List.of(componentInfo), response);
+        assertEquals("hamburger", comboBox.getValue());
+    }
+
+    @Test
+    public void testMSBFillItemInItemListCustomValueNotAllowed() {
+        //create ComponentInfo
+        MultiSelectComboBox<String> multiSelectComboBox = new MultiSelectComboBox<>();
+        multiSelectComboBox.setId("food");
+        multiSelectComboBox.setItems("pizza", "pasta", "salad");
+
+        ComponentUtils.ComponentInfo componentInfo =
+                new ComponentUtils.ComponentInfo("food", "ComboBox", multiSelectComboBox);
+
+        //create AI response
+        Map<String, Object> response = new HashMap<>();
+        // create a list from pizza and pasta
+        response.put("food", new ArrayList<>(List.of("pizza")));
+
+        //fill component
+        ComponentUtils.fillComponents(List.of(componentInfo), response);
+        assertEquals( List.of("pizza"), multiSelectComboBox.getValue().stream().toList());
+    }
+
+    @Test
+    public void testMSBFillItemInItemListCustomValueAllowed() {
+        //create ComponentInfo
+        MultiSelectComboBox<String> multiSelectComboBox = new MultiSelectComboBox<>();
+        multiSelectComboBox.setId("food");
+        multiSelectComboBox.setItems("pizza", "pasta", "salad");
+        multiSelectComboBox.setAllowCustomValue(true);
+
+        ComponentUtils.ComponentInfo componentInfo =
+                new ComponentUtils.ComponentInfo("food", "ComboBox", multiSelectComboBox);
+
+        //create AI response
+        Map<String, Object> response = new HashMap<>();
+        // create a list from pizza and pasta
+        response.put("food", new ArrayList<>(List.of("pizza")));
+
+        //fill component
+        ComponentUtils.fillComponents(List.of(componentInfo), response);
+        assertEquals( List.of("pizza"), multiSelectComboBox.getValue().stream().toList());
+    }
+
+    @Test
+    public void testMSBFillItemsInItemListCustomValueNotAllowed() {
+        //create ComponentInfo
+        MultiSelectComboBox<String> multiSelectComboBox = new MultiSelectComboBox<>();
+        multiSelectComboBox.setId("food");
+        multiSelectComboBox.setItems("pizza", "pasta", "salad");
+
+        ComponentUtils.ComponentInfo componentInfo =
+                new ComponentUtils.ComponentInfo("food", "ComboBox", multiSelectComboBox);
+
+        //create AI response
+        Map<String, Object> response = new HashMap<>();
+        // create a list from pizza and pasta
+        response.put("food", new ArrayList<>(List.of("pizza", "pasta")));
+
+        //fill component
+        ComponentUtils.fillComponents(List.of(componentInfo), response);
+        assertEquals( List.of("pizza", "pasta"), multiSelectComboBox.getValue().stream().toList());
+    }
+
+    @Test
+    public void testMSBFillItemInItemsListCustomValueAllowed() {
+        //create ComponentInfo
+        MultiSelectComboBox<String> multiSelectComboBox = new MultiSelectComboBox<>();
+        multiSelectComboBox.setId("food");
+        multiSelectComboBox.setItems("pizza", "pasta", "salad");
+        multiSelectComboBox.setAllowCustomValue(true);
+
+        ComponentUtils.ComponentInfo componentInfo =
+                new ComponentUtils.ComponentInfo("food", "ComboBox", multiSelectComboBox);
+
+        //create AI response
+        Map<String, Object> response = new HashMap<>();
+        // create a list from pizza and pasta
+        response.put("food", new ArrayList<>(List.of("pizza", "pasta")));
+
+        //fill component
+        ComponentUtils.fillComponents(List.of(componentInfo), response);
+        assertEquals( List.of("pizza", "pasta"), multiSelectComboBox.getValue().stream().toList());
+    }
+
+    @Test
+    public void testMSBFillItemNotInItemListCustomValueNotAllowed() {
+        //create ComponentInfo
+        MultiSelectComboBox<String> multiSelectComboBox = new MultiSelectComboBox<>();
+        multiSelectComboBox.setId("food");
+        multiSelectComboBox.setItems("pizza", "pasta", "salad");
+
+        ComponentUtils.ComponentInfo componentInfo =
+                new ComponentUtils.ComponentInfo("food", "ComboBox", multiSelectComboBox);
+
+        //create AI response
+        Map<String, Object> response = new HashMap<>();
+        // create a list from pizza and pasta
+        response.put("food", new ArrayList<>(List.of("hamburger")));
+
+        //fill component
+        ComponentUtils.fillComponents(List.of(componentInfo), response);
+        assertEquals( List.of(), multiSelectComboBox.getValue().stream().toList());
+    }
+
+    @Test
+    public void testMSBFillItemNotInItemListCustomValueAllowed() {
+        //create ComponentInfo
+        MultiSelectComboBox<String> multiSelectComboBox = new MultiSelectComboBox<>();
+        multiSelectComboBox.setId("food");
+        multiSelectComboBox.setItems("pizza", "pasta", "salad");
+        multiSelectComboBox.setAllowCustomValue(true);
+
+        ComponentUtils.ComponentInfo componentInfo =
+                new ComponentUtils.ComponentInfo("food", "ComboBox", multiSelectComboBox);
+
+        //create AI response
+        Map<String, Object> response = new HashMap<>();
+        // create a list from pizza and pasta
+        response.put("food", new ArrayList<>(List.of("hamburger")));
+
+        //fill component
+        ComponentUtils.fillComponents(List.of(componentInfo), response);
+        assertEquals( List.of("hamburger"), multiSelectComboBox.getValue().stream().toList());
+    }
+
+    @Test
+    public void testMSBFillItemsNotInItemListCustomValueNotAllowed() {
+        //create ComponentInfo
+        MultiSelectComboBox<String> multiSelectComboBox = new MultiSelectComboBox<>();
+        multiSelectComboBox.setId("food");
+        multiSelectComboBox.setItems("pizza", "pasta", "salad");
+
+        ComponentUtils.ComponentInfo componentInfo =
+                new ComponentUtils.ComponentInfo("food", "ComboBox", multiSelectComboBox);
+
+        //create AI response
+        Map<String, Object> response = new HashMap<>();
+        // create a list from pizza and pasta
+        response.put("food", new ArrayList<>(List.of("hamburger", "goulash")));
+
+        //fill component
+        ComponentUtils.fillComponents(List.of(componentInfo), response);
+        assertEquals( List.of(), multiSelectComboBox.getValue().stream().toList());
+    }
+
+    @Test
+    public void testMSBFillItemsNotInItemListCustomValueAllowed() {
+        //create ComponentInfo
+        MultiSelectComboBox<String> multiSelectComboBox = new MultiSelectComboBox<>();
+        multiSelectComboBox.setId("food");
+        multiSelectComboBox.setItems("pizza", "pasta", "salad");
+        multiSelectComboBox.setAllowCustomValue(true);
+
+        ComponentUtils.ComponentInfo componentInfo =
+                new ComponentUtils.ComponentInfo("food", "ComboBox", multiSelectComboBox);
+
+        //create AI response
+        Map<String, Object> response = new HashMap<>();
+        // create a list from pizza and pasta
+        response.put("food", new ArrayList<>(List.of("hamburger", "goulash")));
+
+        //fill component
+        ComponentUtils.fillComponents(List.of(componentInfo), response);
+        assertTrue(multiSelectComboBox.getValue().stream().toList().contains("hamburger"));
+        assertTrue(multiSelectComboBox.getValue().stream().toList().contains("goulash"));
+    }
+
+    @Test
+    public void testMSBFillItemsSomeIsInItemListCustomValueNotAllowed() {
+        //create ComponentInfo
+        MultiSelectComboBox<String> multiSelectComboBox = new MultiSelectComboBox<>();
+        multiSelectComboBox.setId("food");
+        multiSelectComboBox.setItems("pizza", "pasta", "salad");
+
+        ComponentUtils.ComponentInfo componentInfo =
+                new ComponentUtils.ComponentInfo("food", "ComboBox", multiSelectComboBox);
+
+        //create AI response
+        Map<String, Object> response = new HashMap<>();
+        // create a list from pizza and pasta
+        response.put("food", new ArrayList<>(List.of("pizza", "goulash")));
+
+        //fill component
+        ComponentUtils.fillComponents(List.of(componentInfo), response);
+        assertTrue(multiSelectComboBox.getValue().stream().toList().contains("pizza"));
+    }
+
+    @Test
+    public void testMSBFillItemsSomeIsInItemListCustomValueAllowed() {
+        //create ComponentInfo
+        MultiSelectComboBox<String> multiSelectComboBox = new MultiSelectComboBox<>();
+        multiSelectComboBox.setId("food");
+        multiSelectComboBox.setItems("pizza", "pasta", "salad");
+        multiSelectComboBox.setAllowCustomValue(true);
+
+        ComponentUtils.ComponentInfo componentInfo =
+                new ComponentUtils.ComponentInfo("food", "ComboBox", multiSelectComboBox);
+
+        //create AI response
+        Map<String, Object> response = new HashMap<>();
+        // create a list from pizza and pasta
+        response.put("food", new ArrayList<>(List.of("pizza", "goulash")));
+
+        //fill component
+        ComponentUtils.fillComponents(List.of(componentInfo), response);
+        assertTrue(multiSelectComboBox.getValue().stream().toList().contains("pizza"));
+        assertTrue(multiSelectComboBox.getValue().stream().toList().contains("goulash"));
+    }
+}

--- a/src/test/java/com/vaadin/flow/ai/formfiller/views/FormFillerTextDemo.java
+++ b/src/test/java/com/vaadin/flow/ai/formfiller/views/FormFillerTextDemo.java
@@ -88,6 +88,7 @@ public class FormFillerTextDemo extends Div {
         ComboBox<String> orderEntity = new ComboBox<>("Order Entity");
         orderEntity.setId("orderEntity");
         orderEntity.setItems("Person", "Company");
+        orderEntity.setAllowCustomValue(false);
         formLayout.add(orderEntity);
 
         NumberField orderTotal = new NumberField("Order Total");
@@ -117,6 +118,7 @@ public class FormFillerTextDemo extends Div {
         formLayout.add(typeService);
 
         MultiSelectComboBox<String> typeServiceMulti = new MultiSelectComboBox<>("Type of Service");
+        typeServiceMulti.setAllowCustomValue(false);
         typeServiceMulti.setItems("Software", "Hardware", "Consultancy");
         typeServiceMulti.setId("typeServiceMs");
         formLayout.add(typeServiceMulti);
@@ -216,11 +218,8 @@ public class FormFillerTextDemo extends Div {
         ComboBox<String> texts = new ComboBox<>("Select a text or just type your own <br>in the debug Input Source field");
         texts.setItems("Text1", "Text2", "Text3");
         texts.setValue("Text1");
-        texts.setAllowCustomValue(false);
         debugTool.getDebugInput().setValue(getExampleTexts().get("Text1"));
-        texts.addValueChangeListener(e -> {
-            debugTool.getDebugInput().setValue(getExampleTexts().get(texts.getValue()));
-        });
+        texts.addValueChangeListener(e -> debugTool.getDebugInput().setValue(getExampleTexts().get(texts.getValue())));
 
         Button fillButton = new Button("Fill Form From Input Text");
         fillButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);


### PR DESCRIPTION
## Description

Based on slack discussions (Leif's suggestions): values can only be AI-filled into ComboBoxes and MultiSelectComboBoxes, if:
- The values are already present in the items list
OR
- The values aren't in the items list, but the 'allow custom values' option is set to true.

Fixes # (issue)
- https://github.com/vaadin/form-filler-addon/issues/125

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
