### PR TITLE
feat: making developer build/use cleaner  (changes in the pom.xml: make development profile default and add jetty:run as well as goal, remove production profile)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,8 @@ Starting the test/demo server:
  mvn jetty:run -Pdevelopment
 ```
 
+Hint: Ensure you activate the development profile. This includes the vaadin-server, making the URLs below accessible. Without this profile, the dependency remains in the provided scope, and the Vaadin demo URL paths won't load or be reachable.
+
 This deploys demos at http://localhost:8080, http://localhost:8080/receipt and http://localhost:8080/invoice
  
 ### Integration test

--- a/README.md
+++ b/README.md
@@ -319,8 +319,6 @@ Starting the test/demo server:
  mvn jetty:run -Pdevelopment
 ```
 
-Hint: Ensure you activate the development profile. This includes the vaadin-server, making the URLs below accessible. Without this profile, the dependency remains in the provided scope, and the Vaadin demo URL paths won't load or be reachable.
-
 This deploys demos at http://localhost:8080, http://localhost:8080/receipt and http://localhost:8080/invoice
  
 ### Integration test

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ public class FormTest extends Div {
 ![Screenshot 2023-08-16 at 20 25 09](https://github.com/vaadin/form-filler-addon/assets/106953874/3b2fad67-a95e-424b-9bc5-8e240c1cd215)
 
 
-___This is an experimental feature and it may be removed, altered, or limited to commercial subscribers in future releases.___
+___This is an experimental feature, and it may be removed, altered, or limited to commercial subscribers in future releases.___
 
 ## Requirements ##
 
@@ -316,7 +316,7 @@ In these examples we use snapshots from 1 page documents to get the text. In bot
 
 Starting the test/demo server:
 ```
- mvn jetty:run -Pdevelopment
+ mvn
 ```
 
 Hint: Ensure you activate the development profile. This includes the vaadin-server, making the URLs below accessible. Without this profile, the dependency remains in the provided scope, and the Vaadin demo URL paths won't load or be reachable.

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 
     <properties>
         <vaadin.version>24.2-SNAPSHOT</vaadin.version>
+        <jetty.plugin.version>11.0.15</jetty.plugin.version>
 
         <maven.jar.plugin.version>3.3.0</maven.jar.plugin.version>
         <maven.compiler.source>17</maven.compiler.source>
@@ -187,7 +188,7 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>11.0.15</version>
+                <version>${jetty.plugin.version}}</version>
                 <configuration>
                     <scan>1</scan>
                     <!-- Use test scope because the UI/test classes are in
@@ -241,6 +242,9 @@
     <profiles>
         <profile>
             <id>development</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>com.vaadin</groupId>
@@ -248,39 +252,26 @@
                     <artifactId>vaadin-core</artifactId>
                 </dependency>
             </dependencies>
-        </profile>
-
-        <profile>
-            <!-- Production mode is activated using -Pproduction -->
-            <id>production</id>
-            <properties>
-                <vaadin.productionMode>true</vaadin.productionMode>
-            </properties>
-
-            <dependencies>
-                <dependency>
-                    <groupId>com.vaadin</groupId>
-                    <artifactId>flow-server-production-mode</artifactId>
-                </dependency>
-            </dependencies>
 
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.vaadin</groupId>
-                        <artifactId>vaadin-maven-plugin</artifactId>
+                        <groupId>org.eclipse.jetty</groupId>
+                        <artifactId>jetty-maven-plugin</artifactId>
+                        <version>${jetty.plugin.version}</version>
                         <executions>
                             <execution>
+                                <phase>validate</phase>
                                 <goals>
-                                    <goal>build-frontend</goal>
+                                    <goal>run</goal>
                                 </goals>
-                                <phase>compile</phase>
                             </execution>
                         </executions>
                     </plugin>
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <id>it</id>
             <build>


### PR DESCRIPTION
## Description

Mikhail had some very good proposals on what we should change in pom.xml affecting the developer flow:
- Remove the `production` profile entirely,
- Add `development` as the default profile,
- add `jetty:run` as goal

With these changes, only `mvn` command is enough to run the addon (and the setup environment variables).
This works like a charm as I commented on the above PR.

Relevant PR:
-https://github.com/vaadin/form-filler-addon/pull/127

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guidelines.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
