### PR TITLE
fix: pom.xml development/dev profile related changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ In these examples we use snapshots from 1 page documents to get the text. In bot
 
 Starting the test/demo server:
 ```
- mvn
+ mvn -Pdev
 ```
 
 Hint: Ensure you activate the development profile. This includes the vaadin-server, making the URLs below accessible. Without this profile, the dependency remains in the provided scope, and the Vaadin demo URL paths won't load or be reachable.

--- a/pom.xml
+++ b/pom.xml
@@ -241,10 +241,7 @@
 
     <profiles>
         <profile>
-            <id>development</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
+            <id>dev</id>
             <dependencies>
                 <dependency>
                     <groupId>com.vaadin</groupId>


### PR DESCRIPTION
## Description
We discussed to not having specific, unique build configs, because harder to maintain or keep in mind.

The following changes happened/happening here:
- profile renamed  `development` -> `dev`
- the dev profile is not activate by default anymore
- README.md changes related to the previous points, 
- **build config** reverted back the changes in the 3. steps mvn clean install build, so removing the profile skip
(delete `-P-development` from parameters list)

The changes were tested and `mvn clean install` and both `mvn -Pdev` work perfectly)

Referring to this PR:
- https://github.com/vaadin/form-filler-addon/pull/129
- and our Slack discussions with Mikhail

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
