### PR TITLE
fix: Check if key is blank

### DIFF
--- a/src/main/java/com/vaadin/flow/ai/formfiller/utils/KeysUtils.java
+++ b/src/main/java/com/vaadin/flow/ai/formfiller/utils/KeysUtils.java
@@ -11,11 +11,11 @@ public class KeysUtils {
     static {
         // read apiKey from -D param variable
         OPEN_AI_KEY = System.getProperty("OPENAI_TOKEN");
-        if (OPEN_AI_KEY == null) {
+        if (OPEN_AI_KEY == null || OPEN_AI_KEY.isBlank()) {
             // read apiKey from environment variable
             OPEN_AI_KEY = System.getenv("OPENAI_TOKEN");
         }
-        if(OPEN_AI_KEY != null) {
+        if (OPEN_AI_KEY != null && !OPEN_AI_KEY.isBlank()) {
             logger.info("OPENAI_TOKEN was filled properly");
         } else {
             logger.error("OPENAI_TOKEN was not filled properly");


### PR DESCRIPTION
Checks that the key from system property is not blank.
The demo project sets in to an empty string by default, so that lead to a false positive check.

Fixes https://github.com/vaadin/form-filler-demo/issues/5