### PR TITLE
fix: Changed the ChatGPTService model to gpt-3.5-turbo-instruct.

### DIFF
--- a/src/main/java/com/vaadin/flow/ai/formfiller/services/ChatGPTService.java
+++ b/src/main/java/com/vaadin/flow/ai/formfiller/services/ChatGPTService.java
@@ -16,7 +16,7 @@ public class ChatGPTService extends OpenAiService implements LLMService {
     /**
      * ID of the model to use.
      */
-    private String MODEL = "text-davinci-003";
+    private String MODEL = "gpt-3.5-turbo-instruct";
 
     /**
      * The maximum number of tokens to generate in the completion.


### PR DESCRIPTION
## Description

From the OpenAI documentation:
- https://platform.openai.com/docs/guides/text-generation

None of the other models mentioned were able to function, except this `gpt-3.5-turbo-instruct` appears to work and is capable of producing a JSON response.

With this change, we can also use the `/` (text to fill) example and the ChatGPT Service.
So this is also a solution and maybe even better than #149

## Type of change

- [x] Bugfix
- [ ] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
