### PR TITLE
get rid of CVE-2021-47621

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,16 @@
                     <groupId>com.squareup.okhttp3</groupId>
                     <artifactId>okhttp</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.github.classgraph</groupId>
+                    <artifactId>classgraph</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.github.classgraph</groupId>
+            <artifactId>classgraph</artifactId>
+            <version>4.8.174</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
`io.github.classgraph:classgraph:jar:4.8.21:compile` has been reported with CVE-2021047621
as `com.theokanning.openai-gpt3-java:service:jar:0.16.0` is already end-of-support, let us exclude the vulnerable dep and upgrade it  separately.